### PR TITLE
fixed a typo in source value

### DIFF
--- a/pica2instance.xsl
+++ b/pica2instance.xsl
@@ -25,7 +25,7 @@
   </xsl:template>
 
   <xsl:template match="metadata">
-    <source>K10Plus</source>
+    <source>K10plus</source>
     <xsl:variable name="ppn" select="datafield[@tag='003@']/subfield[@code='0']" />
     <hrid>
       <xsl:value-of select="$ppn" />


### PR DESCRIPTION
Value is now aligned with the official name of the data source: https://wiki.k10plus.de/