### PR TITLE
--pull --no-cache for docker build

### DIFF
--- a/harvester/db/build-docker.sh
+++ b/harvester/db/build-docker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cp -a ../../sql .
-docker build -t mariadb10-11-pica:latest .
+docker build -t mariadb10-11-pica:latest --pull --no-cache .


### PR DESCRIPTION
`--pull` ensures that the latest MariaDB patch release is used so that we don't miss any security vulnerability fixes.

`--no-cache` doesn't reuse potentially outdated layers. This option avoids surprises and should always be used for releases.